### PR TITLE
Fix standard error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,6 @@ Rails.application.configure do
     config.hosts = hosts.compact
   end
 
-
   # Rails logging
   config.lograge.enabled = true
 end

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/app-test
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      AUTOMATICALLY_FIX_LINTING: "true"
+      AUTOMATICALLY_FIX_LINTING: "false"
     volumes:
       - .:/srv/app
     tty: true


### PR DESCRIPTION
We had a Standard error that snuck through because `AUTOMATICALLY_FIX_LINTING` was set to `true` in CI