### PR TITLE
Don’t try and lint CSVs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,5 +24,6 @@
 *.sh
 *.txt
 *.gz
+*.csv
 /public/assets/*
 /coverage


### PR DESCRIPTION
This adds the `*.csv` pattern to `.prettierignore` so it doesn't complain when running `prettier --fix`