### PR TITLE
Rename 'show' action to 'vote'

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -1,7 +1,7 @@
 class PlacesController < ActionController::Base
   layout "application"
 
-  def show
+  def vote
     @place = Place.not_rated_by(uuid).random.first || Place.random.first
     @vote = @place.votes.new(uuid: uuid)
   end

--- a/app/views/places/vote.html.erb
+++ b/app/views/places/vote.html.erb
@@ -1,3 +1,7 @@
+<aside>
+  ScenicOrNot helps you to explore every corner of England, Scotland and Wales, all the while comparing your aesthetic judgements with fellow players.
+</aside>
+
 <div id="rate">
   <div>
     <% (1..10).to_a.each do |i| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,10 @@
 Rails.application.routes.draw do
   get "health_check" => "application#health_check"
 
-  root to: "places#show"
+  root to: "places#vote"
 
-  resources :places, only: [:show] do
+  resources :places do
+    get "vote", to: "places#vote"
     resources :votes, only: [:create]
   end
 


### PR DESCRIPTION
## Changes in this PR
- Rename the `show` action to `vote` to better reflect its purpose, and to allow us to use `show` for its intended purpose in the near future
