### PR TITLE
(41) Add site footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,5 +20,16 @@
       <%= render "layouts/messages" %>
       <%= yield %>
     </main>
+    <footer>
+      <p>A mini-project originally created for <a href="http://www.mysociety.org">mySociety</a>. Now hosted by the <a href="http://datasciencelab.co.uk/"> Data Science Lab</a>, <a href="http://www.wbs.ac.uk/">Warwick Business School.</a></p>
+      <ul>
+        <li>
+          <a href="http://datasciencelab.co.uk/contact-us/">Contact us</a>
+        </li>
+        <li>
+          <a href="/cookies">Privacy and cookies</a>
+        </li>
+      </ul>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
This adds the site footer, with links to the cookies page and the contact us page for the Data Science Lab (ported from the original site)

## Screenshots

![image](https://user-images.githubusercontent.com/109774/165104323-62bb57bd-9d5a-46bc-94e7-de6dcb5f7b62.png)
