### PR TITLE
(43) Change bottom 5 options

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,32 +2,4 @@ class Vote < ApplicationRecord
   belongs_to :place
 
   validates_uniqueness_of :uuid, scope: :place
-
-  def self.most_scenic_places
-    results = ActiveRecord::Base.connection.execute(top_query)
-    if results.entries.size < 5
-      results = ActiveRecord::Base.connection.execute(top_query(min_score: 5, min_vote_count: 1))
-    end
-    results.entries
-  end
-
-  def self.least_scenic_places
-    results = ActiveRecord::Base.connection.execute(bottom_query)
-    if results.entries.size < 5
-      results = ActiveRecord::Base.connection.execute(bottom_query(max_score: 5, min_vote_count: 1))
-    end
-    results.entries
-  end
-
-  def self.top_query(min_score: 9, min_vote_count: 3, num_places: 5)
-    "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
-    "GROUP BY place_id HAVING avg(rating) > #{min_score} AND count(place_id) >= #{min_vote_count} " \
-    "ORDER BY score DESC, vote_count DESC LIMIT #{num_places}"
-  end
-
-  def self.bottom_query(max_score: 1, min_vote_count: 3, num_places: 5)
-    "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
-    "GROUP BY place_id HAVING avg(rating) <= #{max_score} AND count(place_id) >= #{min_vote_count} " \
-    "ORDER BY score ASC, vote_count DESC LIMIT #{num_places}"
-  end
 end

--- a/app/presenters/leaderboard_presenter.rb
+++ b/app/presenters/leaderboard_presenter.rb
@@ -3,12 +3,16 @@ class LeaderboardPresenter
 
   TOTAL_UK_LAND_AREA_IN_SQ_KM = 241930
 
+  def initialize(leaderboard: Leaderboard.new)
+    @leaderboard = leaderboard
+  end
+
   def top_five
-    Vote.most_scenic_places.map { |result| PlaceWithRating.new(result) }
+    @leaderboard.most_scenic_places.map { |result| PlaceWithRating.new(result) }
   end
 
   def bottom_five
-    Vote.least_scenic_places.map { |result| PlaceWithRating.new(result) }
+    @leaderboard.least_scenic_places.map { |result| PlaceWithRating.new(result) }
   end
 
   def percentage_coverage

--- a/app/services/leaderboard.rb
+++ b/app/services/leaderboard.rb
@@ -1,0 +1,45 @@
+class Leaderboard
+  NUM_PLACES_IN_TOP = 5
+
+  DEFAULT_OPTIONS = {
+    min_score: 9,
+    max_score: 2,
+    min_vote_count: 3
+  }
+
+  FALLBACK_OPTIONS = {
+    min_score: 5,
+    max_score: 3,
+    min_vote_count: 1
+  }
+
+  def most_scenic_places
+    results = ActiveRecord::Base.connection.execute(top_query)
+    if results.entries.size < NUM_PLACES_IN_TOP
+      results = ActiveRecord::Base.connection.execute(top_query(FALLBACK_OPTIONS))
+    end
+    results.entries
+  end
+
+  def least_scenic_places
+    results = ActiveRecord::Base.connection.execute(bottom_query)
+    if results.entries.size < NUM_PLACES_IN_TOP
+      results = ActiveRecord::Base.connection.execute(bottom_query(FALLBACK_OPTIONS))
+    end
+    results.entries
+  end
+
+  private
+
+  def top_query(options = DEFAULT_OPTIONS)
+    "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
+    "GROUP BY place_id HAVING avg(rating) > #{options[:min_score]} AND count(place_id) >= #{options[:min_vote_count]} " \
+    "ORDER BY score DESC, vote_count DESC LIMIT #{NUM_PLACES_IN_TOP}"
+  end
+
+  def bottom_query(options = DEFAULT_OPTIONS)
+    "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
+    "GROUP BY place_id HAVING avg(rating) <= #{options[:max_score]} AND count(place_id) >= #{options[:min_vote_count]} " \
+    "ORDER BY score ASC, vote_count DESC LIMIT #{NUM_PLACES_IN_TOP}"
+  end
+end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -23,42 +23,4 @@ RSpec.describe Vote, type: :model do
       expect(place2_vote.valid?).to be_truthy
     end
   end
-
-  context "most and least scenic places" do
-    let(:most_scenic_place) { FactoryBot.create(:place) }
-    let(:least_scenic_place) { FactoryBot.create(:place) }
-
-    before do
-      FactoryBot.create_list(:vote, 3, place: most_scenic_place, rating: 10)
-      FactoryBot.create_list(:vote, 3, place: least_scenic_place, rating: 1)
-      FactoryBot.create_list(:vote, 5, rating: 8)
-      FactoryBot.create_list(:vote, 5, rating: 3)
-    end
-
-    describe ".most_scenic_places" do
-      it "returns the top 5 rated places" do
-        top_five = Vote.most_scenic_places
-
-        expect(top_five.size).to eql(5)
-        expect(top_five.first).to match(hash_including(
-          "place_id" => most_scenic_place.id,
-          "score" => 10,
-          "vote_count" => 3
-        ))
-      end
-    end
-
-    describe ".least_scenic_places" do
-      it "returns the bottom 5 rated places" do
-        bottom_five = Vote.least_scenic_places
-
-        expect(bottom_five.size).to eql(5)
-        expect(bottom_five.first).to match(hash_including(
-          "place_id" => least_scenic_place.id,
-          "score" => 1,
-          "vote_count" => 3
-        ))
-      end
-    end
-  end
 end

--- a/spec/presenters/leaderboard_presenter_spec.rb
+++ b/spec/presenters/leaderboard_presenter_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe LeaderboardPresenter, type: :presenter do
       }
     }
     let(:place) { FactoryBot.build(:place) }
+    let(:leaderboard) { double(:leaderboard, most_scenic_places: [result]) }
 
     before do
-      allow(Vote).to receive(:most_scenic_places).and_return([result])
       allow(Place).to receive(:find).and_return(place)
     end
 
     it "returns an array with the top five places and their stats" do
-      top_place = LeaderboardPresenter.new.top_five.first
+      top_place = LeaderboardPresenter.new(leaderboard: leaderboard).top_five.first
 
       expect(top_place.score).to eql("9.5")
       expect(top_place.vote_count).to eql(7)
@@ -34,14 +34,14 @@ RSpec.describe LeaderboardPresenter, type: :presenter do
       }
     }
     let(:place) { FactoryBot.build(:place) }
+    let(:leaderboard) { double(:leaderboard, least_scenic_places: [result]) }
 
     before do
-      allow(Vote).to receive(:least_scenic_places).and_return([result])
       allow(Place).to receive(:find).and_return(place)
     end
 
-    it "returns an array with the top five places and their stats" do
-      bottom_place = LeaderboardPresenter.new.bottom_five.first
+    it "returns an array with the bottom five places and their stats" do
+      bottom_place = LeaderboardPresenter.new(leaderboard: leaderboard).bottom_five.first
 
       expect(bottom_place.score).to eql("1.5")
       expect(bottom_place.vote_count).to eql(7)

--- a/spec/services/leaderboard_spec.rb
+++ b/spec/services/leaderboard_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Leaderboard, type: :service do
+  context "most and least scenic places" do
+    let(:most_scenic_place) { FactoryBot.create(:place) }
+    let(:least_scenic_place) { FactoryBot.create(:place) }
+
+    before do
+      FactoryBot.create_list(:vote, 3, place: most_scenic_place, rating: 10)
+      FactoryBot.create_list(:vote, 3, place: least_scenic_place, rating: 1)
+      FactoryBot.create_list(:vote, 5, rating: 8)
+      FactoryBot.create_list(:vote, 5, rating: 3)
+    end
+
+    describe "most_scenic_places" do
+      it "returns the top 5 rated places" do
+        top_five = Leaderboard.new.most_scenic_places
+
+        expect(top_five.size).to eql(5)
+        expect(top_five.first).to match(hash_including(
+          "place_id" => most_scenic_place.id,
+          "score" => 10,
+          "vote_count" => 3
+        ))
+      end
+    end
+
+    describe "least_scenic_places" do
+      it "returns the bottom 5 rated places" do
+        bottom_five = Leaderboard.new.least_scenic_places
+
+        expect(bottom_five.size).to eql(5)
+        expect(bottom_five.first).to match(hash_including(
+          "place_id" => least_scenic_place.id,
+          "score" => 1,
+          "vote_count" => 3
+        ))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
We’ve changed the options as follows:
- maximum rating for bottom 5 is 2 by default, with 3 as a fallback[1]

[1] Ratings tend to be quite stern, so even a score of 5 for a built-up
area is a pretty good score.
