### PR TITLE
(44) Calculate and show percentage rated

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -12,4 +12,11 @@ class Place < ApplicationRecord
   def to_param
     "#{id}-#{title.parameterize}"
   end
+
+  def self.with_enough_votes(options)
+    Place.joins(:votes)
+      .group(:id)
+      .having("count(place_id) >= :min_vote_count", {min_vote_count: options[:min_vote_count]})
+      .entries
+  end
 end

--- a/app/presenters/leaderboard_presenter.rb
+++ b/app/presenters/leaderboard_presenter.rb
@@ -1,8 +1,6 @@
 class LeaderboardPresenter
   include ActionView::Helpers::NumberHelper
 
-  TOTAL_UK_LAND_AREA_IN_SQ_KM = 241930
-
   def initialize(leaderboard: Leaderboard.new)
     @leaderboard = leaderboard
   end
@@ -15,7 +13,7 @@ class LeaderboardPresenter
     @leaderboard.least_scenic_places.map { |result| PlaceWithRating.new(result) }
   end
 
-  def percentage_coverage
-    number_with_precision((Place.count.to_f / TOTAL_UK_LAND_AREA_IN_SQ_KM * 100), precision: 2, strip_insignificant_zeros: true)
+  def percentage_rated
+    "#{number_with_precision(@leaderboard.percentage_rated, precision: 2, strip_insignificant_zeros: true)}%"
   end
 end

--- a/app/services/leaderboard.rb
+++ b/app/services/leaderboard.rb
@@ -13,6 +13,8 @@ class Leaderboard
     min_vote_count: 1
   }
 
+  TOTAL_UK_LAND_AREA_IN_SQ_KM = 234387.8
+
   def most_scenic_places
     results = ActiveRecord::Base.connection.execute(top_query)
     if results.entries.size < NUM_PLACES_IN_TOP
@@ -27,6 +29,10 @@ class Leaderboard
       results = ActiveRecord::Base.connection.execute(bottom_query(FALLBACK_OPTIONS))
     end
     results.entries
+  end
+
+  def percentage_rated
+    Place.with_enough_votes(DEFAULT_OPTIONS).count.to_f / TOTAL_UK_LAND_AREA_IN_SQ_KM * 100
   end
 
   private

--- a/app/views/places/leaderboard.html.erb
+++ b/app/views/places/leaderboard.html.erb
@@ -2,7 +2,7 @@
   <h2>Leaderboard</h2>
 
   <p>
-    This page shows the current prettiest and ugliest places, according to your votes. It only uses the votes we've gathered so far, and that's only <%= @leaderboard.percentage_coverage %>% of the country - if you think that they're wrong, get voting!
+    This page shows the current prettiest and ugliest places, according to your votes. It only uses the votes we've gathered so far, and that's only <%= @leaderboard.percentage_rated %> of the country - if you think that they're wrong, get voting!
   </p>
 
   <div id="leaderboard">

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe Place, type: :model do
     end
   end
 
+  describe ".with_enough_votes" do
+    let(:place) { FactoryBot.create(:place) }
+    let(:options) { {min_vote_count: 3} }
+
+    before do
+      FactoryBot.create_list(:vote, 3, place: place)
+      # places without enough votes
+      FactoryBot.create(:place)
+      place_1_vote = FactoryBot.create(:place)
+      FactoryBot.create(:vote, place: place_1_vote)
+    end
+
+    it "returns the places with at least n votes" do
+      expect(Place.with_enough_votes(options)).to eql([place])
+    end
+  end
+
   describe "#map_link" do
     it "generates an OpenStreetMap link from the latitude and longitude" do
       place = build(:place)

--- a/spec/presenters/leaderboard_presenter_spec.rb
+++ b/spec/presenters/leaderboard_presenter_spec.rb
@@ -49,11 +49,13 @@ RSpec.describe LeaderboardPresenter, type: :presenter do
     end
   end
 
-  describe "percentage_coverage" do
-    it "calculates the coverage of the territory" do
-      allow(Place).to receive(:count).and_return(120000)
+  describe "percentage_rated" do
+    let(:places) { double(:places, count: 200000) }
 
-      expect(LeaderboardPresenter.new.percentage_coverage).to eql("49.6")
+    it "displays the percentage of territory with places having received at least 3 votes" do
+      allow(Place).to receive(:with_enough_votes).and_return(places)
+
+      expect(LeaderboardPresenter.new.percentage_rated).to eql("85.33%")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Replace "percentage coverage" with "percentage rated"

Percentage rated is defined as percentage of sq km in Great Britain [1]
with an image with 3 or more votes. (Not every sq km has an image.)

[1] Number taken from
https://geoportal.statistics.gov.uk/documents/a-beginners-guide-to-uk-geography-2021-v1-0/explore
