### PR TITLE
(47) Link to data download in the footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ people, to help limit abuse, or the impact of people with terrible taste.
 
 ## Who built it?
 
-Scenic-or-Not was originally built by
-[dxw](https://www.dxw.com/) for
+Scenic-or-Not was originally built by [dxw](https://www.dxw.com/) for
 [mySociety](http://www.mysociety.org/). It is now hosted by the
 [Data Science Lab](http://datasciencelab.co.uk/) at
 [Warwick Business School](http://www.wbs.ac.uk/).

--- a/app/assets/stylesheets/footer.sass.scss
+++ b/app/assets/stylesheets/footer.sass.scss
@@ -6,5 +6,10 @@
     font-size: 0.8em;
     text-align: center;
     flex-shrink: 0;
+
+    ul li {
+      display: inline-block;
+      margin-right: 10px;
+    }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,9 @@
           <a href="http://datasciencelab.co.uk/contact-us/">Contact us</a>
         </li>
         <li>
+          <%= link_to "Data downloads", data_downloads_path %>
+        </li>
+        <li>
           <a href="/cookies">Privacy and cookies</a>
         </li>
       </ul>


### PR DESCRIPTION
## Changes in this PR
- Add link to the Data downloads page to the footer

## Screenshots of UI changes

### After

#### On desktop / width >= 950px
<img width="840" alt="Screenshot 2022-04-28 at 12 57 30" src="https://user-images.githubusercontent.com/579522/165747059-0932b46f-f600-4918-9f59-14aa99f482ac.png">

#### On mobile / width < 950px
<img width="406" alt="Screenshot 2022-04-28 at 12 58 41" src="https://user-images.githubusercontent.com/579522/165747182-34eb32ca-bb39-4ddc-b48d-0050a041e46d.png">
