### PR TITLE
(50) Exclude some places from data collection and leaderboard

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,6 +1,7 @@
 class Place < ApplicationRecord
   has_many :votes
 
+  scope :active, -> { where(active_on_geograph: true) }
   scope :random, -> { order(Arel.sql("RANDOM()")) }
   scope :rated_by, ->(uuid) { joins(:votes).where(votes: {uuid: uuid}) }
   scope :not_rated_by, ->(uuid) { where.not(id: rated_by(uuid).pluck(:id)) }

--- a/app/services/leaderboard.rb
+++ b/app/services/leaderboard.rb
@@ -39,12 +39,16 @@ class Leaderboard
 
   def top_query(options = DEFAULT_OPTIONS)
     "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
+    "JOIN places ON votes.place_id = places.id " \
+    "WHERE places.active_on_geograph = true " \
     "GROUP BY place_id HAVING avg(rating) > #{options[:min_score]} AND count(place_id) >= #{options[:min_vote_count]} " \
     "ORDER BY score DESC, vote_count DESC LIMIT #{NUM_PLACES_IN_TOP}"
   end
 
   def bottom_query(options = DEFAULT_OPTIONS)
     "SELECT place_id, count(place_id) AS vote_count, avg(rating) AS score FROM votes " \
+    "JOIN places ON votes.place_id = places.id " \
+    "WHERE places.active_on_geograph = true " \
     "GROUP BY place_id HAVING avg(rating) <= #{options[:max_score]} AND count(place_id) >= #{options[:min_vote_count]} " \
     "ORDER BY score ASC, vote_count DESC LIMIT #{NUM_PLACES_IN_TOP}"
   end

--- a/app/services/place_picker.rb
+++ b/app/services/place_picker.rb
@@ -4,18 +4,33 @@ class PlacePicker
   end
 
   def place
-    goldilock_place || Place.not_rated_by(uuid).random.first || Place.random.first
-  end
-
-  def goldilock_place(min_vote_count: 0, max_vote_count: 3)
-    Place.not_rated_by(uuid)
-      .joins(:votes)
-      .group("places.id")
-      .having("count('votes.place_id') > :min AND count('votes.place_id') <= :max", {min: min_vote_count, max: max_vote_count})
-      .random.first
+    eligible_places.first
   end
 
   private
 
   attr_reader :uuid
+
+  def eligible_places
+    return goldilock_places if goldilock_places.any?
+    return places_not_rated_by_user if places_not_rated_by_user.any?
+
+    all_active_places
+  end
+
+  def goldilock_places(min_vote_count: 0, max_vote_count: 3)
+    Place.active.not_rated_by(uuid)
+      .joins(:votes)
+      .group("places.id")
+      .having("count('votes.place_id') > :min AND count('votes.place_id') <= :max", {min: min_vote_count, max: max_vote_count})
+      .random
+  end
+
+  def places_not_rated_by_user
+    Place.active.not_rated_by(uuid).random
+  end
+
+  def all_active_places
+    Place.active.random
+  end
 end

--- a/db/migrate/20220428132450_add_active_on_geograph_to_places.rb
+++ b/db/migrate/20220428132450_add_active_on_geograph_to_places.rb
@@ -1,0 +1,5 @@
+class AddActiveOnGeographToPlaces < ActiveRecord::Migration[7.0]
+  def change
+    add_column :places, :active_on_geograph, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_21_162919) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_28_132450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_21_162919) do
     t.string "geograph_image_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active_on_geograph", default: true
   end
 
   create_table "votes", force: :cascade do |t|

--- a/spec/services/leaderboard_spec.rb
+++ b/spec/services/leaderboard_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Leaderboard, type: :service do
           "vote_count" => 3
         ))
       end
+
+      it "does not include any inactive places" do
+        most_scenic_place.update(active_on_geograph: false)
+
+        top_five = Leaderboard.new.most_scenic_places
+        expect(top_five.collect { |r| r["place_id"] }).to_not include(most_scenic_place.id)
+      end
     end
 
     describe "least_scenic_places" do
@@ -33,6 +40,13 @@ RSpec.describe Leaderboard, type: :service do
           "score" => 1,
           "vote_count" => 3
         ))
+      end
+
+      it "does not include any inactive places" do
+        least_scenic_place.update(active_on_geograph: false)
+
+        bottom_five = Leaderboard.new.least_scenic_places
+        expect(bottom_five.collect { |r| r["place_id"] }).to_not include(least_scenic_place.id)
       end
     end
   end

--- a/spec/services/place_picker_spec.rb
+++ b/spec/services/place_picker_spec.rb
@@ -46,5 +46,11 @@ RSpec.describe PlacePicker, type: :service do
         end
       end
     end
+
+    it "never selects a place that is not active_on_geograph" do
+      place_rated_by_user.update(active_on_geograph: false)
+
+      expect(PlacePicker.new(uuid).place).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Exclude images that are no longer available on Geograph from any further data collection
- Also exclude them from the leaderboard (because we can't show them)
