### PR TITLE
(48) Silently ignore duplicate votes

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -2,11 +2,10 @@ class VotesController < ApplicationController
   def create
     vote = Vote.new(vote_params.merge(place_id: params[:place_id], uuid: uuid))
 
-    if vote.save
-      session[:just_rated_place_id] = vote.place_id
-    else
-      flash[:error] = t("votes.duplicate")
-    end
+    # Under normal operating conditions the user should never be shown a place they've already rated
+    # so we silently ignore duplicate votes to not disrupt the user's experience
+    vote.save
+    session[:just_rated_place_id] = vote.place_id
 
     redirect_to root_path
   end

--- a/config/locales/votes.yml
+++ b/config/locales/votes.yml
@@ -1,3 +1,0 @@
-en:
-  votes:
-    duplicate: "You cannot vote on a place more than once"

--- a/spec/requests/votes_spec.rb
+++ b/spec/requests/votes_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Voting", type: :request do
     expect(flash[:error]).to be_nil
   end
 
-  it "flashes an error message when the vote is unsuccessful" do
-    vote_stub = double(:vote, save: false)
+  it "redirects to the index page when the vote is unsuccessful" do
+    vote_stub = double(:vote, save: false, place_id: 123)
 
     expect(Vote).to receive(:new).with(
       ActionController::Parameters.new({
@@ -36,6 +36,8 @@ RSpec.describe "Voting", type: :request do
 
     post("/places/123/votes", params: {vote: {rating: 4}})
 
-    expect(flash[:error]).to eq(I18n.t("votes.duplicate"))
+    expect(response).to redirect_to(root_path)
+
+    expect(flash[:error]).to be_nil
   end
 end


### PR DESCRIPTION
## Changes in this PR

Under normal operating conditions the user should never be shown a place
they've already rated - this is not under their control, and there’s
nothing they can do to avoid being shown a place they’ve already rated,
in the unlikely event that this happened.

The duplicate vote is not saved, but we are letting the user compare
their intended rating with other users (in the spirit of the game).

This was the original approach as well.

## Screenshots of UI changes

### Before
<img width="480" alt="Screenshot 2022-04-27 at 15 08 13" src="https://user-images.githubusercontent.com/579522/166440256-189b15f7-f616-4ce9-81e0-cd283f1bebbe.png">

### After

Nothing different from the usual post-vote view.