### PR TITLE
Improve place picker performance

### DIFF
--- a/app/services/place_picker.rb
+++ b/app/services/place_picker.rb
@@ -4,7 +4,7 @@ class PlacePicker
   end
 
   def place
-    eligible_places.first
+    eligible_places.present? ? Place.find(eligible_places.sample) : nil
   end
 
   private
@@ -12,25 +12,22 @@ class PlacePicker
   attr_reader :uuid
 
   def eligible_places
-    return goldilock_places if goldilock_places.any?
-    return places_not_rated_by_user if places_not_rated_by_user.any?
-
-    all_active_places
+    goldilock_place_ids.presence || place_ids_not_rated_by_user.presence || all_active_place_ids
   end
 
-  def goldilock_places(min_vote_count: 0, max_vote_count: 3)
+  def goldilock_place_ids(min_vote_count: 0, max_vote_count: 3)
     Place.active.not_rated_by(uuid)
       .joins(:votes)
       .group("places.id")
       .having("count('votes.place_id') > :min AND count('votes.place_id') <= :max", {min: min_vote_count, max: max_vote_count})
-      .random
+      .pluck(:id)
   end
 
-  def places_not_rated_by_user
-    Place.active.not_rated_by(uuid).random
+  def place_ids_not_rated_by_user
+    Place.active.not_rated_by(uuid).pluck(:id)
   end
 
-  def all_active_places
-    Place.active.random
+  def all_active_place_ids
+    Place.active.pluck(:id)
   end
 end


### PR DESCRIPTION
Postgres’s `random` feature is not very perfomant, especially with big datasets, so we’re removing it and instead returning all the IDs, then using `sample` to grab a random ID and perform a `find` query. This cuts down the `goldilock_places` query time by about 50%.