### PR TITLE
(67) Remove bold styling from leaderboard title

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -2,7 +2,7 @@
   display: grid;
   gap: 20px;
 
-  h3 {
+  h2 {
     color: #d9d1aa;
     font-size: 1.7em;
     line-height: 1em;
@@ -62,7 +62,7 @@
   }
 
   #most-scenic {
-    h3 {
+    h2 {
       padding-left: 40px;
       background: url("/assets/top-5.png") left no-repeat;
       height: 44px;
@@ -72,7 +72,7 @@
   }
 
   #least-scenic {
-    h3 {
+    h2 {
       padding-left: 55px;
       background: url("/assets/bottom-5.png") bottom left no-repeat;
       height: 44px;

--- a/app/assets/stylesheets/mobile.sass.scss
+++ b/app/assets/stylesheets/mobile.sass.scss
@@ -93,7 +93,7 @@ $secondary: #c7b199;
 }
 
 #leaderboard {
-  h3 {
+  h2 {
     font-weight: bold;
   }
 }

--- a/app/views/places/leaderboard.html.erb
+++ b/app/views/places/leaderboard.html.erb
@@ -1,5 +1,5 @@
 <div id="content">
-  <h2>Leaderboard</h2>
+  <h1>Leaderboard</h1>
 
   <p>
     This page shows the current prettiest and ugliest places, according to your votes. It only uses the votes we've gathered so far, and that's only <%= @leaderboard.percentage_rated %> of the country - if you think that they're wrong, get voting!

--- a/app/views/places/leaderboard.html.erb
+++ b/app/views/places/leaderboard.html.erb
@@ -7,7 +7,7 @@
 
   <div id="leaderboard">
     <div id="most-scenic">
-      <h3>Top 5</h3>
+      <h2>Top 5</h2>
       <div class="inner">
         <ol>
           <% @leaderboard.top_five.each do |rated_place| %>
@@ -20,7 +20,7 @@
     </div>
 
     <div id="least-scenic">
-      <h3>Bottom 5</h3>
+      <h2>Bottom 5</h2>
       <div class="inner">
         <ol>
           <% @leaderboard.bottom_five.each do |rated_place| %>
@@ -32,5 +32,4 @@
       </div>
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
## Changes in this PR
- Make headings on the Leaderboard page consistent

## Screenshots of UI changes

### Before
<img width="528" alt="Screenshot 2022-05-03 at 12 04 39" src="https://user-images.githubusercontent.com/579522/166442397-e1ffb2ca-22b0-411b-b4ca-6f32268c1a2a.png">

### After
<img width="553" alt="Screenshot 2022-05-03 at 12 03 54" src="https://user-images.githubusercontent.com/579522/166442320-2f276bd9-91fe-46dd-ae15-5725e664ed1b.png">
