### PR TITLE
(68) Remove extra "Cookies" heading on privacy page

### DIFF
--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,13 +1,9 @@
-
 <div id="content">
-
   <h1>Privacy, cookies, and third party services</h1>
-
-  <h2>Cookies</h2>
 
   <p>To make our service easier or more useful, we sometimes place small data files on your computer or mobile phone, known as cookies; many websites do this. We use this information to, for example, prevent duplicate votes, or to measure how people use the website so we can improve it and make sure it works properly. Below, we list the cookies and services that this site can use.</p>
 
-  <h3>Strictly necessary cookies</h3>
+  <h2>Strictly necessary cookies</h2>
 
   <p> These cookies do not store your personal data but are required for the service to operate: </p>
 
@@ -29,7 +25,7 @@
     </tr>
   </table>
 
-  <h3>Cookies that measure website use</h3>
+  <h2>Cookies that measure website use</h2>
 
   <p>We use Google Analytics software to collect anonymised information about how you use ScenicOrNot. We do this to help make sure the site is meeting the needs of its users and to help us make improvements to the site.</p>
   <p>We do not allow Google to use or share the data about how you use this site.</p>


### PR DESCRIPTION
## Changes in this PR
- Remove extra "Cookies" heading on privacy page

## Screenshots of UI changes

### Before
<img width="553" alt="Screenshot 2022-05-03 at 12 09 24" src="https://user-images.githubusercontent.com/579522/166443007-8e10bff6-636a-4285-abed-86d682699e15.png">

### After
<img width="543" alt="Screenshot 2022-05-03 at 12 09 01" src="https://user-images.githubusercontent.com/579522/166443027-0356edea-8aec-4e32-8363-952864c32bc9.png">

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
