### PR TITLE
(61) Only show the place just rated immediately after voting

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -22,7 +22,7 @@ class PlacesController < ActionController::Base
   end
 
   def just_rated_place_id
-    session[:just_rated_place_id]
+    params[:just_rated_place_id]
   end
 
   def just_rated_place

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -5,9 +5,8 @@ class VotesController < ApplicationController
     # Under normal operating conditions the user should never be shown a place they've already rated
     # so we silently ignore duplicate votes to not disrupt the user's experience
     vote.save
-    session[:just_rated_place_id] = vote.place_id
 
-    redirect_to root_path
+    redirect_to root_path(just_rated_place_id: vote.place_id)
   end
 
   private

--- a/spec/features/the_home_page_shows_a_random_place_spec.rb
+++ b/spec/features/the_home_page_shows_a_random_place_spec.rb
@@ -9,5 +9,10 @@ RSpec.describe "Home page shows a random place" do
     # Then I expect to see a random place
     expect(page).to have_content("Photo by Namey Nameson")
     expect(page).to have_content("Licence")
+
+    # And I expect to see a brief explanation of what ScenicOrNot is
+    within("aside") do
+      expect(page).to have_content("ScenicOrNot helps you to explore every corner")
+    end
   end
 end

--- a/spec/features/user_rates_a_place_spec.rb
+++ b/spec/features/user_rates_a_place_spec.rb
@@ -20,5 +20,16 @@ RSpec.describe "A user rates a place" do
     # And I am shown another place to rate
     other_place = Place.where.not(id: voted_place.id).first
     expect(page).to have_content("Photo by #{other_place.creator}")
+
+    # When I go to another page
+    visit root_path
+
+    # Then I am not shown the previously rated place
+    within("aside") do
+      expect(page).to have_content("ScenicOrNot helps you to explore every corner")
+      expect(page).to_not have_content("You've just rated:")
+      expect(page).to_not have_content(voted_place.title)
+      expect(page).to_not have_content("Rating: 5 (from 1 votes)")
+    end
   end
 end

--- a/spec/requests/votes_spec.rb
+++ b/spec/requests/votes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Voting", type: :request do
 
     post("/places/123/votes", params: {vote: {rating: 4}})
 
-    expect(response).to redirect_to(root_path)
+    expect(response).to redirect_to(root_path(just_rated_place_id: "123"))
 
     expect(flash[:error]).to be_nil
   end
@@ -36,7 +36,7 @@ RSpec.describe "Voting", type: :request do
 
     post("/places/123/votes", params: {vote: {rating: 4}})
 
-    expect(response).to redirect_to(root_path)
+    expect(response).to redirect_to(root_path(just_rated_place_id: "123"))
 
     expect(flash[:error]).to be_nil
   end


### PR DESCRIPTION
## Changes in this PR
-  Only show the place just rated immediately after voting, by sending it as a query parameter instead of storing it in a session cookie
