### PR TITLE
(78) Add word breaking to FAQ content

### DIFF
--- a/app/assets/stylesheets/generic.sass.scss
+++ b/app/assets/stylesheets/generic.sass.scss
@@ -40,6 +40,14 @@ a:hover {
   display: none;
 }
 
+dl.content {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  word-break: break-word;
+}
+
 @media (min-width: 950px) {
   .hide-desktop {
     display: none;


### PR DESCRIPTION
## Changes in this PR
- Wrap long strings such as URLs to keep them inside their container

(I've used learnings from https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/)

## Screenshots of UI changes

### Before
<img width="656" alt="Screenshot 2022-05-03 at 16 15 39" src="https://user-images.githubusercontent.com/579522/166482412-45ddd829-99a6-49a8-a0b4-8326921e9030.png">

### After
<img width="462" alt="Screenshot 2022-05-03 at 16 15 11" src="https://user-images.githubusercontent.com/579522/166482333-a12d5e55-e744-41db-b29b-c2b3e0d174b9.png">

