### PR TITLE
(65) Ensure the leaderboard columns have equal width

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -1,5 +1,7 @@
 #leaderboard {
   display: grid;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
   gap: 20px;
 
   h2 {


### PR DESCRIPTION
## Changes in this PR
- Ensure the two leaderboard columns are given equal width

## Screenshots of UI changes

### Before
<img width="544" alt="Screenshot 2022-05-03 at 16 30 50" src="https://user-images.githubusercontent.com/579522/166485193-788f2fcd-05a7-4917-bc8d-a96fbbd221e8.png">

### After
<img width="576" alt="Screenshot 2022-05-03 at 16 22 25" src="https://user-images.githubusercontent.com/579522/166485040-e41bab2b-47f7-45a6-ac91-e248617848e0.png">
