### PR TITLE
Remove deprecated cookie from Privacy page

### DIFF
--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -18,11 +18,6 @@
       <td>A random unique identifier</td>
       <td>When web browser is closed</td>
     </tr>
-    <tr>
-      <td>just_rated_place_id</td>
-      <td>The ID of the most recently rated place</td>
-      <td>When web browser is closed</td>
-    </tr>
   </table>
 
   <h2>Cookies that measure website use</h2>


### PR DESCRIPTION
## Changes in this PR
- Remove deprecated cookie `just_rated_place_id` from Privacy page
