### PR TITLE
Store the last rated place ID in the session

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -22,7 +22,7 @@ class PlacesController < ActionController::Base
   end
 
   def just_rated_place_id
-    params[:just_rated_place_id]
+    @just_rated_place_id ||= session.delete(:just_rated_place_id)
   end
 
   def just_rated_place

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -6,7 +6,9 @@ class VotesController < ApplicationController
     # so we silently ignore duplicate votes to not disrupt the user's experience
     vote.save
 
-    redirect_to root_path(just_rated_place_id: vote.place_id)
+    session[:just_rated_place_id] = vote.place_id
+
+    redirect_to root_path
   end
 
   private

--- a/spec/requests/votes_spec.rb
+++ b/spec/requests/votes_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe "Voting", type: :request do
 
     post("/places/123/votes", params: {vote: {rating: 4}})
 
-    expect(response).to redirect_to(root_path(just_rated_place_id: "123"))
+    expect(response).to redirect_to(root_path)
 
+    expect(session[:just_rated_place_id]).to eq(123)
     expect(flash[:error]).to be_nil
   end
 
@@ -36,8 +37,9 @@ RSpec.describe "Voting", type: :request do
 
     post("/places/123/votes", params: {vote: {rating: 4}})
 
-    expect(response).to redirect_to(root_path(just_rated_place_id: "123"))
+    expect(response).to redirect_to(root_path)
 
+    expect(session[:just_rated_place_id]).to eq(123)
     expect(flash[:error]).to be_nil
   end
 end


### PR DESCRIPTION
Here we revert to the “old” method of storing the last rated place ID in the session, but instead of just fetching it, we fetch and delete it using `Hash#delete`(https://apidock.com/ruby/Hash/delete). This way, when we refresh the page, we’re not shown the place we last voted on again.