### PR TITLE
(87) Speed up image loading - part 1

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,4 +7,4 @@
 
 DATABASE_URL=postgres://postgres@localhost:5432/scenic-or-not-test
 
-S3_HOSTNAME="test"
+IMAGE_HOSTNAME="test"

--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,5 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/scenic-or-not-test
+
+S3_HOSTNAME="test"

--- a/app/helpers/place_helper.rb
+++ b/app/helpers/place_helper.rb
@@ -1,6 +1,6 @@
 module PlaceHelper
   def place_thumbnail(place, thumbnail_is_link: false)
-    thumbnail = "<img src='#{place.image_uri}' width='90px' alt='#{place.title}' />".html_safe
+    thumbnail = "<img src='#{place.image_location}' width='90px' alt='#{place.title}' />".html_safe
     return thumbnail unless thumbnail_is_link
 
     link_to(thumbnail, place_path(place.to_param))

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -22,6 +22,6 @@ class Place < ApplicationRecord
   end
 
   def image_location
-    [ENV["S3_HOSTNAME"], image_uri].join("/")
+    [ENV["IMAGE_HOSTNAME"], image_uri].join("/")
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -20,4 +20,8 @@ class Place < ApplicationRecord
       .having("count(place_id) >= :min_vote_count", {min_vote_count: options[:min_vote_count]})
       .entries
   end
+
+  def image_location
+    [ENV["S3_HOSTNAME"], image_uri].join("/")
+  end
 end

--- a/app/presenters/place_with_rating.rb
+++ b/app/presenters/place_with_rating.rb
@@ -3,7 +3,7 @@ class PlaceWithRating
 
   attr_reader :place, :vote_count
 
-  delegate :id, :title, :image_uri, :map_link, :to_param, to: :place
+  delegate :id, :title, :image_location, :map_link, :to_param, to: :place
 
   def initialize(result)
     @place = Place.find(result["place_id"])

--- a/app/views/places/_place.html.erb
+++ b/app/views/places/_place.html.erb
@@ -1,7 +1,7 @@
 <div id="place">
   <picture>
-    <source src="<%= place.image_uri %>">
-    <img src="<%= place.image_uri %>" alt="<%= place.title %>" />
+    <source src="<%= place.image_location %>">
+    <img src="<%= place.image_location %>" alt="<%= place.title %>" />
   </picture>
 </div>
 

--- a/db/seeds/places.rb
+++ b/db/seeds/places.rb
@@ -25,7 +25,6 @@ SmarterCSV.process(places_filename, chunk_size: 1000) do |chunk|
   chunk.each do |row|
     geograph_id = row[:geograph_uri].split("/").last
     image_code = row[:image_uri].split("/").last
-    image_uri = [ENV["S3_HOSTNAME"], image_code].join("/")
 
     rows << {
       id: row[:id],
@@ -47,7 +46,7 @@ SmarterCSV.process(places_filename, chunk_size: 1000) do |chunk|
       height: row[:height],
       aspect: row[:aspect],
       geograph_image_uri: row[:image_uri],
-      image_uri: image_uri,
+      image_uri: image_code,
       active_on_geograph: !inactive_images.include?(geograph_id)
     }
   end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,9 @@
+# :nocov:
+desc "Remove the host name from image_uri"
+task make_image_uri_relative: :environment do
+  Place.find_each do |place|
+    place.image_uri.gsub!(/.+\//, "")
+    place.save!
+  end
+end
+# :nocov:

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe Place, type: :model do
       expect(place.map_link).to eql("https://www.openstreetmap.org/?mlat=#{place.lat}&mlon=#{place.lon}")
     end
   end
+
+  describe "#image_location" do
+    it "concatenates the image host with the image_uri" do
+      place = build(:place, image_uri: "fake_image_code.jpg")
+
+      expect(place.image_location).to eql("test/fake_image_code.jpg")
+    end
+  end
 end


### PR DESCRIPTION
- Make `image_uri` a relative path instead of an absolute one, to avoid being hardcoded into a specific host
- Change the seed script to no longer hardcode the image host
- Calculate the absolute path to the image in the code

These changes will allow us to verify different solutions proposed to speed up the image loading without having to re-code all the places in the database every time.