### PR TITLE
(91) Create a script to export TSV for most recent data

### DIFF
--- a/app/services/export_places_with_votes.rb
+++ b/app/services/export_places_with_votes.rb
@@ -1,0 +1,45 @@
+class ExportPlacesWithVotes
+  def tsv_data
+    CSV.generate(col_sep: "\t") do |csv|
+      csv << csv_headers
+      places_data.each do |row|
+        csv << transform_data(row)
+      end
+    end
+  end
+
+  private
+
+  def transform_data(entry)
+    image_number = entry["image_uri"].match(image_number_regex)[1]
+
+    [
+      entry["geograph_id"],
+      entry["lat"],
+      entry["lon"],
+      entry["avg"].round(4),
+      entry["variance"].round(4),
+      entry["ratings"],
+      "https://www.geograph.org.uk/photo/#{image_number}"
+    ]
+  end
+
+  def csv_headers
+    ["ID", "Lat", "Lon", "Average", "Variance", "Votes", "Geograph URI"]
+  end
+
+  def places_data
+    @places_data ||= ActiveRecord::Base.connection.execute(places_query).entries
+  end
+
+  def image_number_regex
+    @image_number_regex ||= Regexp.new('([1-9]\d*)_')
+  end
+
+  def places_query
+    "SELECT places.id, geograph_id, lat, lon, avg(rating), var_pop(rating) AS variance, string_agg(rating::text, ',') AS ratings, image_uri " \
+    "FROM votes JOIN places ON votes.place_id = places.id " \
+    "WHERE active_on_geograph = true " \
+    "GROUP BY places.id HAVING count(rating) >= 3"
+  end
+end

--- a/lib/tasks/export_tsv.rake
+++ b/lib/tasks/export_tsv.rake
@@ -1,0 +1,9 @@
+desc "Export a TSV summarising the most recent data in the database"
+task export_tsv: :environment do
+  require "fileutils"
+  FileUtils.mkdir_p "tmp"
+
+  votes_file = File.open("tmp/votes.tsv", "wb")
+  votes_file.write(ExportPlacesWithVotes.new.tsv_data)
+  votes_file.close
+end

--- a/spec/lib/tasks/export_tsv_spec.rb
+++ b/spec/lib/tasks/export_tsv_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "export_tsv", type: :task do
+  let(:fake_file) { double(:file) }
+  let(:fake_data) { double(:data) }
+
+  before do
+    allow(FileUtils).to receive(:mkdir_p)
+    allow(File).to receive(:open).and_return(fake_file)
+    allow(fake_file).to receive(:write)
+    allow(fake_file).to receive(:close)
+    allow_any_instance_of(ExportPlacesWithVotes).to receive(:tsv_data).and_return(fake_data)
+  end
+
+  it "writes the TSV data into a file" do
+    expect(FileUtils).to receive(:mkdir_p).with("tmp")
+    expect(File).to receive(:open).with("tmp/votes.tsv", "wb")
+    expect(fake_file).to receive(:write).with(fake_data)
+    expect(fake_file).to receive(:close)
+
+    task.execute
+  end
+end

--- a/spec/services/export_places_with_votes_spec.rb
+++ b/spec/services/export_places_with_votes_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ExportPlacesWithVotes, type: :service do
+  describe "#tsv_data" do
+    let(:expected_headers) { ["ID", "Lat", "Lon", "Average", "Variance", "Votes", "Geograph URI"].join("\t") }
+    let(:place_with_enough_votes) { FactoryBot.create(:place, geograph_id: 7, lat: 51.4073, lon: -0.655554, image_uri: "000340_a49458b3.jpg", active_on_geograph: true) }
+
+    before do
+      FactoryBot.create(:vote, place: place_with_enough_votes, rating: 4)
+      FactoryBot.create(:vote, place: place_with_enough_votes, rating: 6)
+      FactoryBot.create(:vote, place: place_with_enough_votes, rating: 3)
+
+      place_without_enough_votes = FactoryBot.create(:place)
+      FactoryBot.create(:vote, place: place_without_enough_votes)
+    end
+
+    it "aggregates the data into a CSV-ready format" do
+      tsv_data = ExportPlacesWithVotes.new.tsv_data
+
+      expected_data =
+        [
+          expected_headers,
+          [
+            7,
+            51.4073,
+            -0.655554,
+            0.43333e1,
+            0.15556e1,
+            "4,6,3",
+            "https://www.geograph.org.uk/photo/340"
+          ].join("\t")
+        ].join("\n") + "\n"
+
+      expect(tsv_data).to eq(expected_data)
+    end
+
+    it "does not include places that are not active_on_geograph" do
+      place_with_enough_votes.active_on_geograph = false
+      place_with_enough_votes.save!
+
+      tsv_data = ExportPlacesWithVotes.new.tsv_data
+
+      expect(tsv_data).to eq(expected_headers + "\n")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This script collects the data from the database for the specified headers and exports it into a TSV file.
To run this script use command:

``` 
bundle exec rake export_tsv
```

This will write to `tmp/votes.tsv`