### PR TITLE
(87) Part 2: Load images from local folder

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
-# Dotenv
 #
 # This file commits safe environment variables for the test environment.
 # For managing sensitive values and overrides use `/.env.test.local`
@@ -6,5 +5,3 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/scenic-or-not-test
-
-IMAGE_HOSTNAME="test"

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -22,6 +22,6 @@ class Place < ApplicationRecord
   end
 
   def image_location
-    [ENV["IMAGE_HOSTNAME"], image_uri].join("/")
+    [ENV.fetch("IMAGE_HOSTNAME", "geograph_photos"), image_uri].join("/")
   end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -56,10 +56,24 @@ RSpec.describe Place, type: :model do
   end
 
   describe "#image_location" do
-    it "concatenates the image host with the image_uri" do
-      place = build(:place, image_uri: "fake_image_code.jpg")
+    context "when there is an image hostname env var" do
+      it "concatenates the image hostname with the image_uri" do
+        ClimateControl.modify IMAGE_HOSTNAME: "http://test" do
+          place = build(:place, image_uri: "fake_image_code.jpg")
 
-      expect(place.image_location).to eql("test/fake_image_code.jpg")
+          expect(place.image_location).to eql("http://test/fake_image_code.jpg")
+        end
+      end
+    end
+
+    context "when there is no image hostname env var" do
+      it "concatenates the geograph_photos folder name with the image_uri" do
+        ClimateControl.modify IMAGE_HOSTNAME: nil do
+          place = build(:place, image_uri: "fake_image_code.jpg")
+
+          expect(place.image_location).to eql("geograph_photos/fake_image_code.jpg")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Now that the photos have been moved onto the instance, we can load them from the local folder.

We are keeping the option open to define an `IMAGE_HOSTNAME`.

NB: There is currently a bug in production whereby the application doesn't seem to have access to the env var. If this bug is fixed, the value of the env var will also need to be modified to load images from the local folder`geograph_photos`.