### PR TITLE
Allow leaderboard columns to stack on mobile

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -1,7 +1,5 @@
 #leaderboard {
   display: grid;
-  grid-auto-columns: minmax(0, 1fr);
-  grid-auto-flow: column;
   gap: 20px;
 
   h2 {
@@ -86,6 +84,9 @@
 
 @media (min-width: 950px) {
   #leaderboard {
+    grid-auto-columns: minmax(0, 1fr);
+    grid-auto-flow: column;
+
     #most-scenic {
       grid-column: 1 / 2;
     }


### PR DESCRIPTION
## Changes in this PR

The fix applied in c6cf6b1601655794f2ab6de597a2c11b0744e2dd ensured that
the leaderboard columns would have equal width, but it also forced them
into a side by side layout on narrow screens.

This commit makes the equal width fix apply to “wide” (>= 950px) media
only.

## Screenshots of UI changes

### Before
<img width="417" alt="Screenshot 2022-06-20 at 13 43 07" src="https://user-images.githubusercontent.com/579522/174604179-e4b947a6-d425-4fef-b45d-c7b3eac81ace.png">

### After
<img width="401" alt="Screenshot 2022-06-20 at 13 43 23" src="https://user-images.githubusercontent.com/579522/174604240-1172136b-455e-4903-aeef-aa30caee6b75.png">
