### PR TITLE
Fix the width of the image column

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -43,6 +43,7 @@
 
         .place {
           display: grid;
+          grid-template-columns: 90px 1fr;
           font-size: 0.8em;
           gap: 10px;
           margin: 0 0 10px 0;


### PR DESCRIPTION
## Changes in this PR

The width of the thumbnail image is already set in code. We don’t want
the grid column containing the thumbnail to expand, because it creates
misalignment with the text in the description column.

## Screenshots of UI changes

### Before
<img width="414" alt="Screenshot 2022-06-20 at 15 05 37" src="https://user-images.githubusercontent.com/579522/174619617-9be9559a-7504-4f7d-ab41-d48adbcdf711.png">

### After
<img width="384" alt="Screenshot 2022-06-20 at 15 05 22" src="https://user-images.githubusercontent.com/579522/174619645-1b29d994-2fa8-42c5-b375-c7bc21760d7c.png">
