### PR TITLE
Docker compose starts locally

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p 3000 -b '0.0.0.0'
 js: yarn build --watch
 css: yarn build:css --watch
 mobile: yarn build:css:mobile --watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       target: web
       args:
         RAILS_ENV: "development"
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/dev"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
script/no-docker/server will call bin/dev to start the server so we copy this and run it within the Docker context.

The procfile takes care of building assets, without it Rails errors out with assets not existing in the asset pipeline.

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
