### PR TITLE
Fix/89 photo sizing within the frame

### DIFF
--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -84,6 +84,20 @@
         margin: 10px $margin-left 10px $margin-right;
         object-fit: fill;
       }
+
+      &::after {
+        box-shadow: inset 0px 0px 1px 1px #988470;
+        -moz-box-shadow: inset 0px 0px 1px 1px #988470;
+        -webkit-box-shadow: inset 0px 0px 1px 1px #988470;
+        bottom: 13px;
+        content: "";
+        display: block;
+        left: $margin-right;
+        height: auto;
+        position: absolute;
+        right: $margin-left;
+        top: 9px;
+        width: auto;
       }
     }
   }

--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -76,11 +76,14 @@
     }
 
     picture {
-      padding: 15px;
+      $margin-left: 28px;
+      $margin-right: 28px;
 
       img {
-        width: 95%;
-        margin: 10px auto;
+        width: $container-width - ($margin-left + $margin-right);
+        margin: 10px $margin-left 10px $margin-right;
+        object-fit: fill;
+      }
       }
     }
   }

--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -39,13 +39,15 @@
   }
 
   #place {
+    $container-width: 507px;
+
     margin: 0;
     padding: 0;
     background: url("pictureframe-bg.png") repeat-y;
     background-size: contain;
     width: 100%;
     position: relative;
-    width: 490px;
+    width: $container-width;
     z-index: 2;
     top: -5px;
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

We adjust the styleing for the photo frame in 3 ways to make it sit right on wider screens.

1. We increase the width slightly so it matches the rating section above it so they are both aligned vertically
2. The image is scaled to fill the available space, the margins are the adjusted so that the image fits equidistantly to each side of the frame around it
3. Optionally I dropped in a little enhancing box shadow as it was quick to do. The hope here is that it adds a bit of 3d indentation which I thought followed the design. It also breaks up the colour contrast where the image meets the frame it sits atop. If this isn't a good idea we can easily drop it?

## Screenshots of UI changes

### Before

![NewSite-WoodenFrame-Screenshot_2022-05-13_at_13 47 17](https://user-images.githubusercontent.com/912473/184193345-ce6d9a36-2c69-46c9-a0ec-60acd687de27.png)

### After

![Screenshot 2022-08-11 at 18-12-03 ScenicOrNot](https://user-images.githubusercontent.com/912473/184193592-67e00577-4f55-49fd-8b9c-b138f8dfbfc7.png)

![Screenshot 2022-08-11 at 18-12-17 ScenicOrNot](https://user-images.githubusercontent.com/912473/184193597-ed77dab0-c890-41be-8f4e-322c7afe39d1.png)


## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
