### PR TITLE
(98) Fix location names on the leaderboard from overlapping

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -95,5 +95,25 @@
     #least-scenic {
       grid-column: 2 / 2;
     }
+
+    .inner {
+      ol {
+        li {
+          .place {
+            grid-template-columns: auto;
+
+            img {
+              grid-column: 1 / 1;
+              grid-row: 1 / 2;
+            }
+
+            div.details {
+              grid-column: 1 / 1;
+              grid-row: 2 / 2;
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/app/helpers/place_helper.rb
+++ b/app/helpers/place_helper.rb
@@ -1,6 +1,6 @@
 module PlaceHelper
   def place_thumbnail(place, thumbnail_is_link: false)
-    thumbnail = "<img src='#{place.image_location}' width='90px' alt='#{place.title}' />".html_safe
+    thumbnail = "<img src='#{place.image_location}' width='100%' alt='#{place.title}' />".html_safe
     return thumbnail unless thumbnail_is_link
 
     link_to(thumbnail, place_path(place.to_param))

--- a/app/views/places/_place_with_rating.html.erb
+++ b/app/views/places/_place_with_rating.html.erb
@@ -1,9 +1,8 @@
 <div class="place">
   <%= place_thumbnail(place, thumbnail_is_link: thumbnail_is_link) %>
-  <div>
+  <div class="details">
     <strong><%= place.title %></strong>
     <span><%= link_to "(map)", place.map_link %></span>
     <p>Rating: <strong><%= place.score %></strong> (from <%= place.vote_count %> votes)</p>
   </div>
 </div>
-


### PR DESCRIPTION


<!-- Do you need to update the changelog? -->

## Changes in this PR

On wider screens we had the situation where a single long word would push the boundary of the grid layout and look wrong.

The word "Finchampstead" would not be split across multiple lines. Given the limited width of the container there was no where else for it to go except overflow outside.

We played with the idea of using a little CSS to keep the current layout but add an elipsis to long words (see last screenshot):

```
.place {
  overflow: hidden;
  text-overflow: ellipsis;
}
```

The idea that this work describes is slightly more involved. Instead of putting the picture and details side by side in an already narrow layout, we give both its own row and give each element more space to fill. This means the image previews are slightly bigger (possibly easier to see too?) and the text has more room to overflow.

The consequence is that the pages on desktop are now slightly longer than before.

**The thinking is that the product team should review this change and if it's not okay, fall back to the ellipsis option.** 

## Screenshots of UI changes

### Before

<img width="576" alt="Card65-Screenshot_2022-05-03_at_16 22 25" src="https://user-images.githubusercontent.com/912473/184625512-71565099-ec4a-4c87-878d-a91f1fec6bab.png">

### After

![Screenshot 2022-08-15 at 11-43-55 ScenicOrNot](https://user-images.githubusercontent.com/912473/184625366-60e94360-2c3c-4143-b50f-b2b03adb7cc5.png)

It continues to work on mobile as it did before with a smaller image and details spanning one row (I noticed the white text not providing a good level of contrast but as it wasn't the focus of this change I've let it be. One for the backlog?):

![Screenshot 2022-08-15 at 11-52-15 ScenicOrNot](https://user-images.githubusercontent.com/912473/184625378-a478555d-b9f7-4a03-be42-48aa95edbb4f.png)

## Ellipsis idea

![ellipsis](https://user-images.githubusercontent.com/912473/184625766-cd1cf76b-f116-45a9-aab3-9ded731eba13.png)

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
