### PR TITLE
(66) Option 1: Centre leaderboard numbers within the badge image

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -26,19 +26,17 @@
         position: relative;
 
         &::before {
+          display: flex;
+          align-items: center;
+          justify-content: center;
           margin-right: 10px;
           content: counter(item);
           background: url("counter-bg.png");
           background-size: contain;
-          width: 1.5em;
-          height: 1.5em;
-          vertical-align: middle;
+          width: 1.6em;
+          height: 1.6em;
           color: #fff;
-          text-align: center;
-          display: inline-block;
           position: absolute;
-          left: -5px;
-          top: -5px;
         }
 
         .place {
@@ -94,6 +92,26 @@
 
     #least-scenic {
       grid-column: 2 / 2;
+    }
+
+    .inner {
+      ol {
+        li {
+          .place {
+            grid-template-columns: auto;
+
+            img {
+              grid-column: 1 / 1;
+              grid-row: 1 / 2;
+            }
+
+            div.details {
+              grid-column: 1 / 1;
+              grid-row: 2 / 2;
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

[Option 2 can be found here.](https://github.com/thedatascilab/ScenicOrNot/pull/207). Which one do we prefer?

The existing `vertical-align: middle;` didn't seem to be being applied as expected. The inspector reported that it needed to be used together with `display: inline` (or table-cell), which when added doesn't seem to have any effect.

The fixed positioning of `left` and `top` seem to make the situation worse so I opted to remove them. The result is that the badges lean more right across the image however the number is more centrally placed.

This alignment isn't perfect and I think that's because of the font. Some numbers align better (such as 1 and 2) whilst others are worse (3 & 4). I'm going to propose an alternative approach that changes the font.

## Screenshots of UI changes

### Before

![Screenshot 2022-08-15 at 15-00-58 ScenicOrNot](https://user-images.githubusercontent.com/912473/184650161-fc7b7f73-6d0a-4af2-a7bc-77dc1cf1f121.png)

### After

![Screenshot 2022-08-15 at 15-00-09 ScenicOrNot](https://user-images.githubusercontent.com/912473/184650148-3b4aef71-f577-4db0-ae56-13f47e9ea6ae.png)

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
