### PR TITLE
(66) Option 2: Centre leaderboard numbers with new background and font

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -1,3 +1,28 @@
+@mixin flower($colour: #554841, $rotation: 30deg) {
+  content: '';
+  top: 0;
+  left: 0;
+  position: absolute;
+  border-radius: 5px;
+  width: 25px;
+  height: 25px;
+  background-color: $colour;
+  transform: rotate($rotation);
+}
+
+.badge {
+  z-index: 20;
+  @include flower($colour: #554841, $rotation: 15deg);
+}
+
+.badge::before {
+  @include flower($colour: #554841, $rotation: 30deg);
+}
+
+.badge::after {
+  @include flower($colour: #554841, $rotation: -30deg);
+}
+
 #leaderboard {
   display: grid;
   gap: 20px;
@@ -26,6 +51,7 @@
         position: relative;
 
         &::before {
+          z-index: 40;
           position: absolute;
 
           content: counter(item);
@@ -34,19 +60,14 @@
           align-items: center;
           justify-content: center;
 
-          border-radius: 50%;
-          background: #554841;
+          box-sizing: initial;
 
-          outline-width: 2px;
-          outline-color: #554841;
-          outline-style: dotted;
-
-          width: 9px;
-          height: 9px;
-          padding: 9px;
+          width: 8px;
+          height: 8px;
+          padding: 8px;
           color: #fff;
           text-align: center;
-          font: 0.8em Arial, sans-serif;
+          font: 1em Charter, Cambria, Arial, sans-serif;
         }
 
         .place {

--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -26,19 +26,27 @@
         position: relative;
 
         &::before {
-          margin-right: 10px;
+          position: absolute;
+
           content: counter(item);
-          background: url("counter-bg.png");
-          background-size: contain;
-          width: 1.5em;
-          height: 1.5em;
-          vertical-align: middle;
+
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
+          border-radius: 50%;
+          background: #554841;
+
+          outline-width: 2px;
+          outline-color: #554841;
+          outline-style: dotted;
+
+          width: 9px;
+          height: 9px;
+          padding: 9px;
           color: #fff;
           text-align: center;
-          display: inline-block;
-          position: absolute;
-          left: -5px;
-          top: -5px;
+          font: 0.8em Arial, sans-serif;
         }
 
         .place {

--- a/app/views/places/leaderboard.html.erb
+++ b/app/views/places/leaderboard.html.erb
@@ -12,6 +12,7 @@
         <ol>
           <% @leaderboard.top_five.each do |rated_place| %>
             <li>
+              <div class="badge">&nbsp;</div>
               <%= render "place_with_rating", place: rated_place, thumbnail_is_link: true %>
             </li>
           <% end %>
@@ -25,6 +26,7 @@
         <ol>
           <% @leaderboard.bottom_five.each do |rated_place| %>
             <li>
+              <div class="badge">&nbsp;</div>
               <%= render "place_with_rating", place: rated_place, thumbnail_is_link: true %>
             </li>
           <% end %>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

~~[Option 1 can be found here.](https://github.com/thedatascilab/ScenicOrNot/pull/206) Which one do we prefer?~~ [This is the preferred route!](https://trello.com/c/2ivFnBDn/66-centre-numbers-in-leaderboard-ranking-labels#comment-62fe729f75e10513af2978c7) 

The image wasn't of even proportions, it had more empty space on the top and left whilst on the right it was ended abruptly.

![Screenshot 2022-08-15 at 15 36 31](https://user-images.githubusercontent.com/912473/184655912-ab4bcb0c-696a-4ba2-bf75-f71166f78458.png)

This approach first changed the image to a circle background created with CSS. Once we know we have an even circle we could then see it was the font was also putting the number off centre. 

![Screenshot 2022-08-15 at 15 31 29](https://user-images.githubusercontent.com/912473/184656048-4d3b04d3-5b4e-4071-81fa-f03bf35bec0e.png)

If we change to arial the numbers are evenly placed but of course the font is different.

![Screenshot 2022-08-15 at 15 31 22](https://user-images.githubusercontent.com/912473/184656014-f02d5e11-6db2-473a-9dda-7a478b2e9e47.png)

![Screenshot 2022-08-15 at 15 38 25](https://user-images.githubusercontent.com/912473/184656229-f93d0c2f-494c-417a-97c6-3567e10d3de4.png)

We then apply a font that is spaced consistently that looks more similar to Georgia (thanks @suzymoat).

![Screenshot 2022-08-19 at 15 31 05](https://user-images.githubusercontent.com/912473/185662536-110ba0f4-e642-4b15-95d5-2a1e61a861ce.png)

Finally we iterate the css background of the number badge to make it look more like the original flower. This was a bit tricky to apply without rotating the number but we got there.

## Screenshots of UI changes

### Before


<img width="576" alt="Card65-Screenshot_2022-05-03_at_16 22 25" src="https://user-images.githubusercontent.com/912473/184655648-d1187e90-8b21-4402-a6d3-336dce82bb2c.png">

### After

![Screenshot 2022-08-19 at 17-24-00 ScenicOrNot](https://user-images.githubusercontent.com/912473/185664470-d6e01fe7-960a-4d25-8bd1-4fd9e4c87009.png)


![Screenshot 2022-08-19 at 17-24-05 ScenicOrNot](https://user-images.githubusercontent.com/912473/185664482-0b7c7f9f-10e1-4f57-89ce-c91e852b13b1.png)


## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
