### PR TITLE
(58) Tweak voting board

### DIFF
--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -15,6 +15,7 @@
       justify-content: center;
 
       img {
+        padding: 0px 15px 0px 15px;
         width: 63px;
         height: 52px;
         display: inline-block;

--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -23,7 +23,7 @@
       input {
         border: none;
         background: transparent;
-        font: 1.4em $font;
+        font: 1.8em $font;
         color: #fff;
         margin: 10px 0;
         padding: 10px 7px;

--- a/app/assets/stylesheets/rate.sass.scss
+++ b/app/assets/stylesheets/rate.sass.scss
@@ -26,7 +26,7 @@
         font: 1.8em $font;
         color: #fff;
         margin: 10px 0;
-        padding: 10px 7px;
+        padding: 0px 7px;
 
         &:hover {
           text-shadow: 1px 1px #000;


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Small collection of visual changes to the voting board by request.

- Make numbers slightly bigger
- Lift the voting numbers up slightly
- Push the flowers out to the sides a bit

The goal was to take it closer towards the old version of the site:

![OriginalVotingBoard-Screenshot_2022-04-29_at_13 49 31](https://user-images.githubusercontent.com/912473/184662270-f6708022-a675-4fa5-9cf3-bd78ad593eae.png)


## Screenshots of UI changes

### Before

![NewVotingBoard-Screenshot_2022-04-29_at_13 52 22](https://user-images.githubusercontent.com/912473/184661979-288bbd94-6e9c-4b5c-9b65-6829f547b1ea.png)

### After

![Screenshot 2022-08-15 at 16 18 25](https://user-images.githubusercontent.com/912473/184663533-44a50ba7-7a24-48fc-9fbf-ec83f37409ca.png)


## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
