### PR TITLE
Use absolute location for default photos folder

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -22,6 +22,6 @@ class Place < ApplicationRecord
   end
 
   def image_location
-    [ENV.fetch("IMAGE_HOSTNAME", "geograph_photos"), image_uri].join("/")
+    [ENV.fetch("IMAGE_HOSTNAME", "/geograph_photos"), image_uri].join("/")
   end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Place, type: :model do
         ClimateControl.modify IMAGE_HOSTNAME: nil do
           place = build(:place, image_uri: "fake_image_code.jpg")
 
-          expect(place.image_location).to eql("geograph_photos/fake_image_code.jpg")
+          expect(place.image_location).to eql("/geograph_photos/fake_image_code.jpg")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR
- Use absolute location for default photos folder

The images can be loaded from the homepage (AKA the voting page), or
from the show page of an individual place (linked from the leaderboard).

Previously, the default location (used when `IMAGE_HOSTNAME` is not
defined) was given as a relative location folder. Use absolute location
instead.

Note: This fix has been implemented in production by modifying the `IMAGE_HOSTNAME` env var,
which takes precedence over the default value.