### PR TITLE
Reduce font size of headers on privacy and cookies page

### DIFF
--- a/app/assets/stylesheets/content.sass.scss
+++ b/app/assets/stylesheets/content.sass.scss
@@ -40,6 +40,10 @@
         margin: 0;
       }
 
+      h2 {
+        font-size: 1em;
+      }
+
       dl {
         dt {
           padding-top: 10px;


### PR DESCRIPTION
## Changes in this PR
Reduce font size of headers on privacy and cookies page

## Screenshots of UI changes

### Before
![NewSite-PrivacyCookies-Screenshot_2022-05-09_at_13 38 12](https://user-images.githubusercontent.com/632390/186111559-c6d0bc97-79be-460c-a5e3-26ab002b0f25.png)

### After
![Screenshot 2022-08-23 at 09 26 24](https://user-images.githubusercontent.com/632390/186111613-215bb4bc-6651-4f55-b67c-11dc92cff4dc.jpg)

### Mobile (no changes)
![Screenshot 2022-08-23 at 09 27 17](https://user-images.githubusercontent.com/632390/186111700-df08556b-b6b1-4d99-ba1b-8e9afcf7a6bb.jpg)

