### PR TITLE
Actually hide the things with the hidden class

### DIFF
--- a/app/assets/stylesheets/generic.sass.scss
+++ b/app/assets/stylesheets/generic.sass.scss
@@ -40,7 +40,7 @@ a:hover {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 dl.content {


### PR DESCRIPTION
Because we sometimes use ids to style components, and ids have a higher
specificity than classes, we need to make the display property an
override.

Better would be to not use ids in stylesheets, but this will do for now.