### PR TITLE
Small tweak to fix leaderboard numbers on Android

### DIFF
--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -67,7 +67,7 @@
           padding: 8px;
           color: #fff;
           text-align: center;
-          font: 1em Charter, Cambria, Bitstream Charter, Caladea, serif;
+          font: 1em Charter, Cambria, "Bitstream Charter", Caladea, serif;
         }
 
         .place {

--- a/app/assets/stylesheets/leaderboard.sass.scss
+++ b/app/assets/stylesheets/leaderboard.sass.scss
@@ -67,7 +67,7 @@
           padding: 8px;
           color: #fff;
           text-align: center;
-          font: 1em Charter, Cambria, Arial, sans-serif;
+          font: 1em Charter, Cambria, Bitstream Charter, Caladea, serif;
         }
 
         .place {


### PR DESCRIPTION
## Changes in this PR

Small tweak to fix leaderboard numbers on Android, which previously displayed in a sans serif font.

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
