### PR TITLE
Include M1 Macs as valid platforms for bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     launchy (2.5.0)
       addressable (~> 2.7)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-arm64-darwin)
     libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
@@ -195,6 +196,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
@@ -354,6 +357,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
This resolves an issue where native extensions wouldn't install when running `bundle install`.

See https://github.com/rubyjs/mini_racer/issues/227#issuecomment-1014725749