### PR TITLE
Space the cookie banner evenly

### DIFF
--- a/app/assets/stylesheets/cookies.sass.scss
+++ b/app/assets/stylesheets/cookies.sass.scss
@@ -6,11 +6,12 @@
   color: #fff;
   background-color: $link-colour;
   font-size: 0.9em;
-  padding-bottom: 10px;
+  padding: 2em 0;
 
   #textContainer {
-    margin-left: 2%;
-    margin-right: 2%;
+    margin-left: 1em;
+    margin-right: 1em;
+    width: 26em;
     text-align: left;
 
     a:link,
@@ -28,8 +29,8 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin-left: 2%;
-    margin-right: 2%;
+    margin-left: 1em;
+    margin-right: 1em;
 
     .cookieButton {
       margin-top: 5px;
@@ -65,7 +66,17 @@
 
 @media (max-width: 949px) {
   #cookieBanner {
+    padding: 3em 1.5em;
     flex-direction: column;
+
+    #textContainer {
+      margin: 0;
+      width: 100%;
+    }
+
+    #buttonContainer {
+      margin: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mobile.sass.scss
+++ b/app/assets/stylesheets/mobile.sass.scss
@@ -160,20 +160,6 @@ $displayfont: "OPTIOliver-Display";
   }
 }
 
-#cookieBanner {
-  width: 100%;
-  text-align: center;
-  background-color: $secondary;
-  font-size: 0.9em;
-  margin: 0;
-  padding: 1em;
-
-  button {
-    @extend .btn, .btn-primary, .btn-sm;
-    margin: 0.5em;
-  }
-}
-
 #licence {
   @extend .box;
   text-align: center;

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,8 +1,6 @@
 <div id="cookieBanner" class="hidden">
   <div id="textContainer">
-    <p>We use some essential cookies to make this service work.</p>
-    <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-    <p><a href="/cookies" id="cookies-eu-more">Read more about our cookie policy.</a></p>
+    <p>We use some essential cookies to make this service work. We'd also like to use analytics cookies so we can understand how you use the service and make improvements. <a href="/cookies" id="cookies-eu-more">Read more about our cookie policy.</a></p>
   </div>
 
   <div id="buttonContainer">


### PR DESCRIPTION
## Changes in this PR

We tidy up the layout of the cookie banner to match the designs more closely.

## Screenshots of UI changes

### Before

#### Desktop

<img width="1180" alt="Screenshot 2022-09-22 at 19 18 45" src="https://user-images.githubusercontent.com/1027364/191811141-1d4e2396-1bd9-4bb2-aa1b-af4fe0afbc7d.png">

#### Mobile

<img width="533" alt="Screenshot 2022-09-22 at 19 19 49" src="https://user-images.githubusercontent.com/1027364/191811320-770ef3b0-ec87-4226-be1a-2aa62c4998f1.png">

### After

#### Desktop

<img width="1179" alt="Screenshot 2022-09-22 at 19 21 01" src="https://user-images.githubusercontent.com/1027364/191811503-5374501e-408a-4bac-9d1b-144a068c70da.png">

#### Mobile

<img width="536" alt="Screenshot 2022-09-22 at 19 21 33" src="https://user-images.githubusercontent.com/1027364/191811599-dbdb5e3f-ad49-4d29-825c-109fe4aa6a0d.png">

