### PR TITLE
Fix footer spacing

### DIFF
--- a/app/assets/stylesheets/footer.sass.scss
+++ b/app/assets/stylesheets/footer.sass.scss
@@ -1,20 +1,24 @@
+footer {
+  &:before {
+    content: "";
+    width: 100%;
+    height: 20px;
+    background: transparent url("footer-bg.png") top center no-repeat;
+    position: absolute;
+    top: -16px;
+    left: 0;
+  }
+
+  position: relative;
+  font-size: 0.8em;
+  background-color: $footer-bg;
+  padding: 20px;
+  text-align: center;
+}
+
 @media (min-width: 950px) {
   footer {
-    &:before {
-      content: "";
-      width: 100%;
-      height: 20px;
-      background: transparent url("footer-bg.png") top center no-repeat;
-      position: absolute;
-      top: -16px;
-      left: 0;
-    }
-
-    position: relative;
-    background-color: $footer-bg;
     padding: 30px 0;
-    font-size: 0.8em;
-    text-align: center;
     flex-shrink: 0;
 
     ul li {

--- a/app/assets/stylesheets/generic.sass.scss
+++ b/app/assets/stylesheets/generic.sass.scss
@@ -15,6 +15,7 @@ body {
 
 .main-outer-container {
   flex: 1 0 auto;
+  padding-bottom: 30px;
   background: linear-gradient(#ded5b8 0 340px, $background 470px 100%);
 }
 

--- a/app/assets/stylesheets/mobile.sass.scss
+++ b/app/assets/stylesheets/mobile.sass.scss
@@ -197,11 +197,3 @@ $displayfont: "OPTIOliver-Display";
     font-weight: bold;
   }
 }
-
-footer {
-  font-size: 0.8em;
-  background-color: #a2c76c;
-  padding: 20px;
-  text-align: center;
-  margin-top: 38px;
-}


### PR DESCRIPTION
Previous to this change, there was a white space above the footer due to the margin added to create space for the grass graphic pushing the container above it away. By moving that top margin to a bottom padding on the container, we avoid that problem.

We also rationalise some of the styling to minimise the differences between mobile and desktop, meaning the grass now appears on mobile, too.