### PR TITLE
Tweak footer layout on wider screens

### DIFF
--- a/app/assets/stylesheets/footer.sass.scss
+++ b/app/assets/stylesheets/footer.sass.scss
@@ -18,12 +18,6 @@ footer {
 
 @media (min-width: 950px) {
   footer {
-    padding: 30px 0;
-    flex-shrink: 0;
-
-    ul li {
-      display: inline-block;
-      margin-right: 10px;
-    }
+    padding: 20px 20px 36px;
   }
 }


### PR DESCRIPTION
Change footer layout on wider screens to centre footer text vertically and list final three links above each other, as on mobile

## Changes in this PR

## Screenshots of UI changes

### Before

![Before](https://user-images.githubusercontent.com/20559528/192654375-2da7f518-d401-4d06-9d64-2d446d758081.png)

### After

![After](https://user-images.githubusercontent.com/20559528/192654396-510a6bc1-967d-4de8-9c88-35dc53d64af7.png)

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
