### PR TITLE
Update Node.js installation for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,16 @@
 FROM ruby:3.1.4 as base
 LABEL org.opencontainers.image.authors="contact@dxw.com"
 
-RUN curl -L https://deb.nodesource.com/setup_16.x | bash -
+# Install NodeSource Node.js binary distribution
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR 16
+RUN apt-get update
+RUN apt-get install -y nodejs
+# End of Node.js install
+
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.authors="contact@dxw.com"
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR 16
 RUN apt-get update
 RUN apt-get install -y nodejs


### PR DESCRIPTION
## Changes in this PR

The script https://deb.nodesource.com/setup_16.x that was previously used to install Node.js on Docker is now deprecated. Continuing to use the deprecated script adds a 60 second wait to each test run.

This PR implements the updated method for installing Node.js on Ubuntu-based distributions, as outlined here: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions