### PR TITLE
Upgrade to Node.js 20 on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR 16
+ENV NODE_MAJOR 20
 RUN apt-get update
 RUN apt-get install -y nodejs
 # End of Node.js install


### PR DESCRIPTION
## Changes in this PR
Upgrade to Node.js 20 on Docker

The Dockerfile still referred to Node.js 16, but the Node.js version set in .node-version is currently 20.9.0.